### PR TITLE
增加搜索ID直接跳入漫画详情页功能，隐藏漫画和空列表漫画fallback到v1api。

### DIFF
--- a/lib/views/comic/comic_search.dart
+++ b/lib/views/comic/comic_search.dart
@@ -237,6 +237,13 @@ class ComicSearchBarDelegate extends SearchDelegate<String> {
     try {
       var response = await http.get(Uri.parse(Api.comicSearchHotWord));
       List ls = jsonDecode(response.body);
+      if (this.query.contains(RegExp(r'\d'))) {
+        int id = int.parse(this.query.replaceAll(RegExp(r'\D'), ''));
+        ls.insert(0, {
+          "id": id,
+          "name": "id:" + id.toString()
+        });
+      }
       List<SearchHotWord> detail =
           ls.map((i) => SearchHotWord.fromJson(i)).toList();
       if (detail != null) {


### PR DESCRIPTION
已调通，但是有时点进隐藏章节还是会返回灰色空白页，清除应用数据后才能恢复正常。

另外汇报两个bug：评论区有时会显示灰白页，在系统亮度下返回详情页会变最暗。