### PR TITLE
评论页变灰对策，墨水屏友好漫画吐槽，小说id进入

### DIFF
--- a/lib/views/novel/novel_search.dart
+++ b/lib/views/novel/novel_search.dart
@@ -74,7 +74,7 @@ class NovelSearchBarDelegate extends SearchDelegate<String> {
 
   @override
   Widget buildSuggestions(BuildContext context) {
-    if (query.length == 0) {
+    if (this.query.contains(RegExp(r'\d')) ||this.query.length == 0) {
       return FutureBuilder<List<SearchHotWord>>(
         future: loadHotWord(),
         builder: (BuildContext context,
@@ -234,7 +234,19 @@ class NovelSearchBarDelegate extends SearchDelegate<String> {
   Future<List<SearchHotWord>> loadHotWord() async {
     try {
       var response = await http.get(Uri.parse(Api.novelSearchHotWord));
-      List ls = jsonDecode(response.body);
+      List ls;
+      try{
+        ls = jsonDecode(response.body);
+      }catch(e){
+        ls=[];
+      }
+      if (this.query.contains(RegExp(r'\d'))) {
+        int id = int.parse(this.query.replaceAll(RegExp(r'\D'), ''));
+        ls.insert(0, {
+          "id": id,
+          "name": "id:" + id.toString()
+        });
+      }
       List<SearchHotWord> detail =
           ls.map((i) => SearchHotWord.fromJson(i)).toList();
       if (detail != null) {

--- a/lib/views/other/comment_widget.dart
+++ b/lib/views/other/comment_widget.dart
@@ -493,7 +493,11 @@ class _CommentWidgetState extends State<CommentWidget>
           page: _page, ishot: _isHot)));
 
       List jsonMap = jsonDecode(response.body);
-
+      try {
+        jsonMap.forEach((e)=>e['masterComment']=(e['masterComment'] is Map)?e['masterComment'].values.toList():e['masterComment']);
+      } catch (e) {
+        print(e);
+      }
       List<CommentItem> detail =
           jsonMap.map((f) => CommentItem.fromJson(f)).toList();
       if (detail != null) {

--- a/lib/views/reader/comic_tc.dart
+++ b/lib/views/reader/comic_tc.dart
@@ -32,7 +32,7 @@ class ComicTCPageState extends State<ComicTCPage> {
         padding: EdgeInsets.only(left: 8, right: 8, top: 8, bottom: 48),
         child: Wrap(
           children: widget.list.map<Widget>((f) {
-            var color = 0.2;
+            var color = 1;/*0.2;
             if (f.num / 100 >= 1) {
               color = 1;
             } else {
@@ -40,7 +40,7 @@ class ComicTCPageState extends State<ComicTCPage> {
               if (color > 1) {
                 color = 1;
               }
-            }
+            }*/
             return Padding(
               padding: EdgeInsets.all(2),
               child: InkWell(


### PR DESCRIPTION
masterComment项有时候不是数组而是有空值的map，会报错灰屏。
正常：[{},{},{}]
异常：{"0":{},"2":{}} // masterComment[1]被隐藏，于是返回map

透明度高的吐槽和文字的对比度低，墨水屏上会看不见

ps能解决后台时比别的应用更容易被杀掉的问题吗？