### PR TITLE
Update comic_detail.dart

### DIFF
--- a/lib/views/comic/comic_detail.dart
+++ b/lib/views/comic/comic_detail.dart
@@ -114,7 +114,7 @@ class _ComicDetailPageState extends State<ComicDetailPage>
                     onSelected: (e) {
                       if (e == "share") {
                         Share.share(
-                            "${_detail.title}\r\nhttp://m.dmzj.com/info/${_detail.comicPy}.html");
+                            "${_detail.title}\r\nhttp://m.dmzj.com/info/${_detail.comicPy}.html");//推荐换用_detail.id
                       } else {
                         if (_detail == null ||
                             _detail.chapters == null ||
@@ -659,7 +659,7 @@ class _ComicDetailPageState extends State<ComicDetailPage>
           copyright: detail?.copyright ?? int.parse(info['copyright'] ?? '0'),
           firstLetter: detail?.firstLetter ?? info['first_letter'] ?? '',
           comicPy:
-              detail?.comicPy ?? info['comicPy'] ?? info['first_letter'] ?? '',
+              detail?.comicPy ?? info['id'],//info['comicPy'] ?? info['first_letter'] ?? '',
           hidden: detail?.hidden ?? int.parse(info['hidden'] ?? '0'),
           hotNum: detail?.hotNum ?? int.parse(info['hotNum'] ?? '0'),
           hitNum: detail?.hitNum ?? int.parse(info['hitNum'] ?? '0'),


### PR DESCRIPTION
`http://m.dmzj.com/info/${_detail.id}.html`比_detail.comicPy更有利于用id再次定位漫画，是否值得考虑？

对神隐漫画，apiV1没有comicPy项，用firstLetter代替的话，生成的分享链接不合法，这里可以patch成info['id']

能否build最新的apk上传到release里？