### PR TITLE
fix: 切换到v4接口来获取漫画章节数据

### DIFF
--- a/lib/app/api.dart
+++ b/lib/app/api.dart
@@ -5,6 +5,7 @@ import 'package:convert/convert.dart';
 
 class Api {
   static final String apiHost = "https://nnv3api.muwai.com";
+  static final String apiHostV4 = "https://nnv4api.muwai.com";
   static final String version = "3.0.0";
   static String get timeStamp =>
       (DateTime.now().millisecondsSinceEpoch / 1000).toStringAsFixed(0);
@@ -149,7 +150,7 @@ class Api {
 
   /// 漫画章节详情
   static String comicChapterDetail(int comicId, int chapterId) {
-    return "$apiHost/chapter/$comicId/$chapterId.json?${defaultParameter()}";
+    return "$apiHostV4/comic/chapter/$comicId/$chapterId";
   }
 
   /// 漫画章节详情(手机网页)

--- a/lib/views/reader/comic_reader.dart
+++ b/lib/views/reader/comic_reader.dart
@@ -951,6 +951,7 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
       }
 
       var responseStr = utf8.decode(responseBody);
+      print('加密的漫画章节详情数据: $responseStr');
       var jsonMap = jsonDecode(responseStr);
 
       ComicWebChapterDetail detail = ComicWebChapterDetail.fromJson(jsonMap);


### PR DESCRIPTION
切换到v4接口来获取漫画章节数据

https://github.com/zam157/dmzj_flutter/blob/1657375b0ce45049c3eba044c6247f3fe90fa2df/lib/app/api.dart#L153

注：V4的漫画章节接口对数据进行了加密，由于我不熟悉flutter上的rsa加密解密（参考了半天项目里其他接口的解密也搞不出来😭）所以并没有实现解密的过程，可以不merge，就当给大佬做个参考